### PR TITLE
Must install dependencies with rosdep

### DIFF
--- a/source/Guides/ros2_tracing_trace_and_analyze.md
+++ b/source/Guides/ros2_tracing_trace_and_analyze.md
@@ -47,6 +47,12 @@ $ git clone https://gitlab.com/ros-tracing/tracetools_analysis.git
 $ cd ..
 ```
 
+Install dependencies with rosdep.
+```
+$ rosdep update
+$ rosdep install --from-paths src --ignore-src -y --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"
+```
+
 Then build up to `performance_test` and configure it for ROS 2.
 See its [documentation](https://gitlab.com/ApexAI/performance_test#ros-2-middleware-plugins).
 We also need to build `ros2trace` to set up tracing using the `ros2 trace` command and `tracetools_analysis` to analyze the data.

--- a/source/Guides/ros2_tracing_trace_and_analyze.md
+++ b/source/Guides/ros2_tracing_trace_and_analyze.md
@@ -48,7 +48,7 @@ $ cd ..
 ```
 
 Install dependencies with rosdep.
-```
+```sh
 $ rosdep update
 $ rosdep install --from-paths src --ignore-src -y --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"
 ```


### PR DESCRIPTION
Dependencies must be installed before building.

The command is taken directly from [Install dependencies using rosdep](https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Development-Setup.html#install-dependencies-using-rosdep), and installs necessary dependencies. Ideally a minimal rosdep just for the packages we're building is better, but rosdep doesn't install recursive dependencies so I couldn't think of a better way to install just the dependencies we need.